### PR TITLE
Split nodes reference into sub-pages to prevent GitHub timeout

### DIFF
--- a/mkdocs/.gitignore
+++ b/mkdocs/.gitignore
@@ -1,2 +1,2 @@
 ﻿# Output from make_node_reference.py
-reference.md
+/output


### PR DESCRIPTION
Currently, when trying to access the [Logic nodes reference](https://github.com/armory3d/armory/wiki/reference) page, GitHub greets you with this message:

```
This page is taking too long to load.

Sorry about that. Please try refreshing and contact us if the problem persists.
```

Apparently, the loading time for the many images on that page now exceeded the timeout threshold. To circumvent this, the reference will be split into sub-pages, with one page per category section. The table of content and the entire page header stays the same for each page so that it looks like the content changes dynamically.

I will open a separate PR on the Armory repo to update the node context menu to these changes as soon as the wiki is fixed again :) 

@luboslenco I hope it's possible to edit the wiki via Git for non-maintainers, otherwise you might need to take some action to temporarily cut down the reference file so that it loads again. Btw, does the wiki-images repo use Git LFS?